### PR TITLE
WDP180903-6 - Fix missing styles for old price in 'product-box' component

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -186,6 +186,7 @@
                 <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
               </div>
               <div class="price">
+                <div class="old-price">$ 25.00</div>
                 <div class="btn-main-small no-hover">$ 30.00</div>
               </div>
             </div>

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -78,5 +78,29 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+
+    .price {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-wrap: wrap;
+
+      .old-price {
+        display: block;
+        padding: 5px;
+        font-size: 14px;
+        font-weight: 300;
+        color: #A5A5A5;
+        text-decoration: line-through;
+        text-decoration-color: #2a2a2a;
+        white-space: nowrap;
+      }
+
+      .btn-main-small.no-hover {
+        font-size: 16px;
+        font-weight: 500;
+        white-space: nowrap;
+      }
+    }
   }
 }


### PR DESCRIPTION
### Update 'product-box' component. Add 'old-price' class. Minor fixies
Add 'old-price' class for styling price before discount. 'old-price' element (div/span) should be inside container 'price' as prev-sibling of discounted price.
Minor fixes:
- make 'prices' font-size slightly larger (according to design it should be bigger than in regular buttons),
- prevent wrapping after dollar sign in price (according to design there shouldn't be white-space)
![image](https://user-images.githubusercontent.com/34632609/46114752-4f373800-c1f4-11e8-959d-f0ac53cc8d90.png)