### PR TITLE
WDP180903-13 Add RWD for 'features' section

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -102,64 +102,61 @@
       </div>
     </div>
   </header>
+
   <div class="section--features">
     <div class="container">
       <div class="row">
-        <div class="col">
-          <a href="http://example.com" style="text-decoration:none;">
-            <div class="feature-box">
-              <div class="icon">
-                <i class="fas fa-truck"></i>
-              </div>
-              <div class="content">
-                <h5>Free shipping</h5>
-                <p>All orders</p>
-              </div>
+        <div class="col-6 col-lg-3 feature-box-wrapper">
+          <a href="#!" class="feature-box">
+            <div class="icon">
+              <i class="fas fa-truck"></i>
+            </div>
+            <div class="content">
+              <h5>Free shipping</h5>
+              <p>All orders</p>
             </div>
           </a>
         </div>
-        <div class="col">
-          <a href="http://example.com" style="text-decoration:none;">
-            <div class="feature-box">
-              <div class="icon">
-                <i class="fas fa-headphones"></i>
-              </div>
-              <div class="content">
-                <h5>24/7 customer</h5>
-                <p>support</p>
-              </div>
+
+        <div class="col-6 col-lg-3 feature-box-wrapper">
+          <a href="#!" class="feature-box">
+            <div class="icon">
+              <i class="fas fa-headphones"></i>
+            </div>
+            <div class="content">
+              <h5>24/7 customer</h5>
+              <p>support</p>
             </div>
           </a>
         </div>
-        <div class="col">
-          <a href="http://example.com" style="text-decoration:none;">
-            <div class="feature-box">
-              <div class="icon">
-                <i class="fas fa-reply-all"></i>
-              </div>
-              <div class="content">
-                <h5>Money back</h5>
-                <p>guarantee</p>
-              </div>
+
+        <div class="col-6 col-lg-3 feature-box-wrapper">
+          <a href="#!" class="feature-box">
+            <div class="icon">
+              <i class="fas fa-reply-all"></i>
+            </div>
+            <div class="content">
+              <h5>Money back</h5>
+              <p>guarantee</p>
             </div>
           </a>
         </div>
-        <div class="col">
-          <a href="http://example.com" style="text-decoration:none;">
-            <div class="feature-box">
-              <div class="icon">
-                <i class="fas fa-bullhorn"></i>
-              </div>
-              <div class="content">
-                <h5>Member discount</h5>
-                <p>First order</p>
-              </div>
+
+        <div class="col-6 col-lg-3 feature-box-wrapper">
+          <a href="#!" class="feature-box">
+            <div class="icon">
+              <i class="fas fa-bullhorn"></i>
+            </div>
+            <div class="content">
+              <h5>Member discount</h5>
+              <p>First order</p>
             </div>
           </a>
         </div>
       </div>
     </div>
   </div>
+
   <div class="section--products">
     <div class="container">
       <div class="panel-bar">

--- a/src/sass/components/_feature-box.scss
+++ b/src/sass/components/_feature-box.scss
@@ -1,4 +1,17 @@
+a.feature-box {
+  color: inherit;
+  text-decoration: none;
+}
+
 .feature-box {
+  &-wrapper {
+    display: flex;
+    flex-direction: column;
+  }
+
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
   border: 1px solid #b6b6b6;
   text-align: center;
   margin-top: 40px;
@@ -7,6 +20,7 @@
     transform: translateY(-50%);
 
     i {
+      @extend %hover-trans;
       width: 60px;
       height: 60px;
       border-radius: 100%;
@@ -34,6 +48,11 @@
   }
 
   .content {
+    @extend %hover-trans;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     text-transform: uppercase;
     color: rgb(42, 42, 42);
     margin-top: -0.5rem;


### PR DESCRIPTION
Task in [Jira](https://projects.kodilla.com/browse/WDP180903-13).
For add RWD used Bootstrap grid classes.
For make feature-box's equal heights used flexbox.

Additional remarks:

- making equal heights required refactor code from [pull request #4](https://github.com/mjurkowski/WDP-1809-03/pull/4) because wrapping `.feature-box` element into `a` tag made difficult to use flexbox,
- removing underlines in hover state (enforced by Bootstrap) was made by css selector with same specificity rate but applied later than Bootstrap styles instead of inline-style,
- added transiton effect for hover state.
